### PR TITLE
fix remolding bug not going into tile children + hacky optimizations

### DIFF
--- a/src/core/lang/Form.re
+++ b/src/core/lang/Form.re
@@ -68,7 +68,7 @@ let forms: list((string, t)) = [
   ("logical_and", mk_infix("&&", Exp, 5)),
   ("concat", mk_infix("++", Exp, 5)),
   ("cons", mk_infix("::", Exp, 5)),
-  ("type-ann", mk_infix(":", Exp, 5)), // bad sorts
+  // ("type-ann", mk_infix(":", Exp, 5)), // bad sorts
   ("dot-access", mk_infix(".", Exp, 5)), // bad sorts
   ("assign_incr", mk_infix("+=", Exp, 10)), // bad sorts
   ("unary_minus", mk(ss, ["-"], mk_pre(P.fact, Exp, []))),

--- a/src/core/lang/Form.re
+++ b/src/core/lang/Form.re
@@ -41,7 +41,10 @@ let whitespace = [Whitespace.space, Whitespace.linebreak];
    Order in this list determines relative remolding
    priority for forms with overlapping regexps */
 let convex_monos: list((string, (string => bool, list(Mold.t)))) = [
-  ("var", (regexp("^[a-z][a-z0-9_]*$"), [mk_op(Exp, [])])),
+  (
+    "var",
+    (regexp("^[a-z][a-z0-9_]*$"), [mk_op(Exp, []), mk_op(Pat, [])]),
+  ),
   ("num", (regexp("^[0-9]*$"), [mk_op(Exp, []), mk_op(Pat, [])])),
 ];
 

--- a/src/core/tiles/Piece.re
+++ b/src/core/tiles/Piece.re
@@ -53,12 +53,12 @@ let disassemble = (p: t): segment =>
   | Tile(t) => Tile.disassemble(t)
   };
 
-let remold = (p: t) =>
-  switch (p) {
-  | Grout(_)
-  | Whitespace(_) => [p]
-  | Tile(t) => List.map(tile, Tile.remold(t))
-  };
+// let remold = (p: t) =>
+//   switch (p) {
+//   | Grout(_)
+//   | Whitespace(_) => [p]
+//   | Tile(t) => List.map(tile, Tile.remold(t))
+//   };
 
 let shapes =
   get(_ => None, g => Some(Grout.shapes(g)), t => Some(Tile.shapes(t)));

--- a/src/core/tiles/Segment.re
+++ b/src/core/tiles/Segment.re
@@ -131,7 +131,10 @@ and remold_piece = (p: Piece.t, s: Sort.t) =>
           let+ child =
             if (l
                 + 1 == r
-                && List.nth(mold.in_, l) != List.nth(t.mold.in_, l)) {
+                && (
+                  List.nth(mold.in_, l) != List.nth(t.mold.in_, l)
+                  || IncompleteBidelim.contains(t.id, l)
+                )) {
               remold(child, List.nth(mold.in_, l));
             } else {
               [child];

--- a/src/core/tiles/Tile.re
+++ b/src/core/tiles/Tile.re
@@ -38,8 +38,8 @@ let sorted_children = ({mold, shards, children, _}: t) =>
        (l.sort == r.sort ? l.sort : Any, child);
      });
 
-let remold = (t: t): list(t) =>
-  Molds.get(t.label) |> List.map(mold => {...t, mold});
+// let remold = (t: t): list(t) =>
+//   Molds.get(t.label) |> List.map(mold => {...t, mold});
 
 let split_shards = (id, label, mold, shards) =>
   shards |> List.map(i => {id, label, mold, shards: [i], children: []});

--- a/src/core/zipper/Ancestors.re
+++ b/src/core/zipper/Ancestors.re
@@ -29,18 +29,18 @@ let disassemble = ancs =>
      )
   |> Siblings.concat;
 
-let remold = (ancestors: t): list(t) =>
-  List.fold_right(
-    ((a, sibs), remolded) => {
-      open ListUtil.Syntax;
-      let+ ancestors = remolded
-      and+ sibs = Siblings.remold(sibs)
-      and+ a = Ancestor.remold(a);
-      [(a, sibs), ...ancestors];
-    },
-    ancestors,
-    [empty],
-  );
+// let remold = (ancestors: t): list(t) =>
+//   List.fold_right(
+//     ((a, sibs), remolded) => {
+//       open ListUtil.Syntax;
+//       let+ ancestors = remolded
+//       and+ sibs = Siblings.remold(sibs)
+//       and+ a = Ancestor.remold(a);
+//       [(a, sibs), ...ancestors];
+//     },
+//     ancestors,
+//     [empty],
+//   );
 
 let skel = ((a, (pre, suf)): generation): Skel.t => {
   let n = List.length(pre);

--- a/src/core/zipper/IncompleteBidelim.re
+++ b/src/core/zipper/IncompleteBidelim.re
@@ -1,0 +1,32 @@
+type t = Id.Map.t(list(int));
+
+let t = ref(Id.Map.empty);
+
+let contains = (id, i): bool =>
+  switch (Id.Map.find_opt(id, t^)) {
+  | None => false
+  | Some(is) => List.mem(i, is)
+  };
+
+let clear = () => {
+  t := Id.Map.empty;
+};
+
+// assumes seg is fully assembled
+let set = (seg: Base.segment): unit =>
+  t :=
+    seg
+    |> List.filter_map(
+         fun
+         | Piece.Tile(t) => {
+             let (l_shard, r_shard) = Tile.(l_shard(t), r_shard(t));
+             let l = l_shard == 0 ? [] : [l_shard - 1];
+             let r = r_shard == List.length(t.label) - 1 ? [] : [r_shard];
+             let lr = l @ r;
+             lr == [] ? None : Some((t.id, l @ r));
+           }
+         | Grout(_)
+         | Whitespace(_) => None,
+       )
+    |> List.to_seq
+    |> Id.Map.of_seq;

--- a/src/core/zipper/Relatives.re
+++ b/src/core/zipper/Relatives.re
@@ -49,7 +49,8 @@ let disassemble = ({siblings, ancestors}: t): Siblings.t =>
 let remold = ({siblings, ancestors}: t): list(t) => {
   open ListUtil.Syntax;
   // let+ ancestors = Ancestors.remold(ancestors)
-  let+ siblings = Siblings.remold(siblings);
+  let s = Ancestors.sort(ancestors);
+  let+ siblings = Siblings.remold(siblings, s);
   {ancestors, siblings};
 };
 

--- a/src/core/zipper/Relatives.re
+++ b/src/core/zipper/Relatives.re
@@ -48,8 +48,8 @@ let disassemble = ({siblings, ancestors}: t): Siblings.t =>
 
 let remold = ({siblings, ancestors}: t): list(t) => {
   open ListUtil.Syntax;
-  let+ ancestors = Ancestors.remold(ancestors)
-  and+ siblings = Siblings.remold(siblings);
+  // let+ ancestors = Ancestors.remold(ancestors)
+  let+ siblings = Siblings.remold(siblings);
   {ancestors, siblings};
 };
 

--- a/src/core/zipper/Siblings.re
+++ b/src/core/zipper/Siblings.re
@@ -31,10 +31,10 @@ let concat = (sibss: list(t)): t =>
 //   |> List.for_all(((_, shards)) => Shard.consistent_molds(shards) != []);
 // };
 
-let remold = ((pre, suf): t): list(t) => {
+let remold = ((pre, suf): t, s): list(t) => {
   open ListUtil.Syntax;
-  let+ pre = Segment.remold(pre)
-  and+ suf = Segment.remold(suf);
+  let+ pre = Segment.remold(pre, s)
+  and+ suf = Segment.remold(suf, s);
   (pre, suf);
 };
 

--- a/src/core/zipper/Zipper.re
+++ b/src/core/zipper/Zipper.re
@@ -88,8 +88,7 @@ let caret_direction =
     | (Some(l), Some(r))
         when Piece.is_whitespace(l) && Piece.is_whitespace(r) =>
       None
-    | _ =>
-      Siblings.direction_between(sibs_with_sel);
+    | _ => Siblings.direction_between(sibs_with_sel)
     };
   };
 

--- a/src/core/zipper/Zipper.re
+++ b/src/core/zipper/Zipper.re
@@ -268,6 +268,7 @@ let put_down = (z: t): option(t) =>
         Siblings.incomplete_tiles(z.relatives.siblings),
         z.backpack,
       );
+    IncompleteBidelim.set(popped.content);
     {...z, backpack} |> put_selection(popped) |> unselect;
   };
 
@@ -705,7 +706,8 @@ let directional_unselect = (d: Direction.t, z: t) => {
   unselect({...z, selection});
 };
 
-let perform = (a: Action.t, (z, id_gen): state): Action.Result.t(state) =>
+let perform = (a: Action.t, (z, id_gen): state): Action.Result.t(state) => {
+  IncompleteBidelim.clear();
   switch (a) {
   | Move(d) =>
     //NOTE(andrew): not sure if this is best approach to unselection
@@ -757,3 +759,4 @@ let perform = (a: Action.t, (z, id_gen): state): Action.Result.t(state) =>
   | RotateBackpack =>
     Ok(({...z, backpack: Util.ListUtil.rotate(z.backpack)}, id_gen))
   };
+};


### PR DESCRIPTION
Had a bug where I wasn't remolding the children of tiles. Fixing this caused showstopping slowdowns (eg stack overflows on first page load). Optimized remolding so that it reuses existing molds when it can, given our current choice of molds:
- always reuse molds in ancestors (this assumes no molds like java type casts where a label has multiple molds of same output sort but possibly varying input sorts, which would necessitate remolding outside of focal segment if focal segment is one of those tile's children and the edits change the focal segment sort)
- if a new mold assignment for a tile assigns the same sort to a bidelimited child as the original mold AND this bidelimited child was not freshly created by the last edit (eg dropping `=` at the end of `let x` creates a new bidelimited container out of `let` and `=`), reuse the molds for that child
- if a tile has molds whose output sorts are consistent with the bidelimited container sort, filter out other molds from consideration (this assumes tiles always take unidelimited children of same sort as output sort eg so no type-annotation tiles)