### PR TITLE
Basic sort inconsistency display

### DIFF
--- a/src/core/lang/Form.re
+++ b/src/core/lang/Form.re
@@ -46,6 +46,7 @@ let convex_monos: list((string, (string => bool, list(Mold.t)))) = [
     (regexp("^[a-z][a-z0-9_]*$"), [mk_op(Exp, []), mk_op(Pat, [])]),
   ),
   ("num", (regexp("^[0-9]*$"), [mk_op(Exp, []), mk_op(Pat, [])])),
+  ("wild", (regexp("^_$"), [mk_op(Pat, [])])),
 ];
 
 /* C. Compound Forms:

--- a/src/core/tiles/Piece.re
+++ b/src/core/tiles/Piece.re
@@ -24,6 +24,13 @@ let sort =
     t => (t.mold.out, t.mold.in_),
   );
 
+let nib_sorts =
+  get(
+    _ => (Sort.Any, Sort.Any),
+    _ => (Sort.Any, Sort.Any),
+    t => ((t.mold.nibs |> fst).sort, (t.mold.nibs |> snd).sort),
+  );
+
 let sorted_children = get(_ => [], _ => [], Tile.sorted_children);
 
 // let is_balanced =

--- a/src/core/zipper/Relatives.re
+++ b/src/core/zipper/Relatives.re
@@ -71,8 +71,8 @@ let shape_rank = ({siblings, ancestors}: t) => {
 };
 
 let regrout = (d: Direction.t, {siblings, ancestors}: t): IdGen.t(t) => {
-  open /* Direction is side of caret on which to favor for grout insertion */
-       IdGen.Syntax;
+  open IdGen.Syntax; /* Direction is side of caret on which to favor for grout insertion */
+
   let* ancestors = Ancestors.regrout(ancestors);
   let+ siblings = {
     let* ((pre, s_l, trim_l), (trim_r, s_r, suf)) =

--- a/src/web/www/style.css
+++ b/src/web/www/style.css
@@ -507,12 +507,16 @@ svg.rail line.unsorted {
   color: var(--delim-color);
   font-weight: bold;
 }
-.code .extra-bold-delim {
+.code .delim-incomplete {
   color: #ce9600;
   font-weight: bold;
 }
-.code .angry-delim {
+.code .mono-sort-inconsistent {
   color: red;
+}
+.code .delim-sort-inconsistent {
+  color: red;
+  font-weight: bold;
 }
 .code .ap {
   color: var(--ap-color);

--- a/src/web/www/style.css
+++ b/src/web/www/style.css
@@ -508,9 +508,11 @@ svg.rail line.unsorted {
   font-weight: bold;
 }
 .code .extra-bold-delim {
-  /*color: var(--delim-color);*/
   color: #ce9600;
   font-weight: bold;
+}
+.code .angry-delim {
+  color: red;
 }
 .code .ap {
   color: var(--ap-color);


### PR DESCRIPTION
The tiles which are the heads of sort-inconsistent terms get colored red. Could use some cleanup but gonna merge in bc yolo